### PR TITLE
Final update for V1.19

### DIFF
--- a/PVS_Assessment.ps1
+++ b/PVS_Assessment.ps1
@@ -136,9 +136,9 @@
 	No objects are output from this script.  This script creates a text file.
 .NOTES
 	NAME: PVS_Assessment.ps1
-	VERSION: 1.18
+	VERSION: 1.19
 	AUTHOR: Carl Webster, Sr. Solutions Architect at Choice Solutions (with a lot of help from BG a, now former, Citrix dev)
-	LASTEDIT: April 18, 2019
+	LASTEDIT: May 3, 2019
 #>
 
 
@@ -190,6 +190,12 @@ Param(
 #http://www.CarlWebster.com
 #script created August 8, 2015
 #released to the community on February 2, 2016
+#
+#Version 1.19 3-May-2019
+#	Remove the following regkeys from analysis as they are for target devices, not PVS Servers 
+#		(thanks to Johan Parlevliet for pointing this out)
+#		HKLM:\SYSTEM\CurrentControlSet\Services\BNIStack\Parameters\SocketOpenRetryIntervalMS      
+#		HKLM:\SYSTEM\CurrentControlSet\Services\BNIStack\ParametersSocketOpenRetryLimit           
 #
 #Version 1.18 18-Apr-2019
 #	Fix bug reported by Johan Parlevliet 
@@ -1236,8 +1242,6 @@ Function GetMiscRegistryKeys
 	#HKLM:\SOFTWARE\Citrix\ProvisioningServices\StreamProcess          SkipBootMenu                   
 	#HKLM:\SOFTWARE\Citrix\ProvisioningServices\StreamProcess          SkipRIMS                       
 	#HKLM:\SOFTWARE\Citrix\ProvisioningServices\StreamProcess          SkipRIMSforPrivate             
-	#HKLM:\SYSTEM\CurrentControlSet\Services\BNIStack\Parameters       SocketOpenRetryIntervalMS      
-	#HKLM:\SYSTEM\CurrentControlSet\Services\BNIStack\Parameters       SocketOpenRetryLimit           
 	#HKLM:\SYSTEM\CurrentControlSet\Services\BNIStack\Parameters       WcHDNoIntermediateBuffering    
 	#HKLM:\SYSTEM\CurrentControlSet\services\BNIStack\Parameters       WcRamConfiguration             
 	#HKLM:\SYSTEM\CurrentControlSet\Services\BNIStack\Parameters       WcWarningIncrement             
@@ -1276,13 +1280,7 @@ Function GetMiscRegistryKeys
 	#https://support.citrix.com/article/CTX200233
 	Get-RegKeyToObject "HKLM:\SOFTWARE\Citrix\ProvisioningServices\StreamProcess" "SkipRIMSforPrivate" $ComputerName
 
-	#https://support.citrix.com/article/CTX136570
-	Get-RegKeyToObject "HKLM:\SYSTEM\CurrentControlSet\Services\BNIStack\Parameters" "SocketOpenRetryIntervalMS" $ComputerName
-
-	#https://support.citrix.com/article/CTX136570
-	Get-RegKeyToObject "HKLM:\SYSTEM\CurrentControlSet\Services\BNIStack\Parameters" "SocketOpenRetryLimit" $ComputerName
-
-	#https://support.citrix.com/article/CTX126042?_ga=1.42836768.408415398.1458651624
+	#https://support.citrix.com/article/CTX126042
 	Get-RegKeyToObject "HKLM:\SYSTEM\CurrentControlSet\Services\BNIStack\Parameters" "WcHDNoIntermediateBuffering" $ComputerName
 
 	#https://support.citrix.com/article/CTX139849

--- a/PVS_Assessment_ReadMe.rtf
+++ b/PVS_Assessment_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -119,11 +119,11 @@ Hyperlink;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf20\chshdng0\chcfpa
 \leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid2008631076}}{\*\listoverridetable{\listoverride\listid558714133\listoverridecount0\ls1}{\listoverride\listid676005662
 \listoverridecount0\ls2}{\listoverride\listid1940482595\listoverridecount0\ls3}{\listoverride\listid872425844\listoverridecount0\ls4}{\listoverride\listid2008631076\listoverridecount0\ls5}{\listoverride\listid314996233\listoverridecount0\ls6}
 {\listoverride\listid1217358328\listoverridecount0\ls7}{\listoverride\listid642077380\listoverridecount0\ls8}}{\*\rsidtbl \rsid201962\rsid599009\rsid1142629\rsid1262568\rsid2246377\rsid2584501\rsid2585069\rsid3085909\rsid3232403\rsid3637189\rsid4090611
-\rsid4482658\rsid4940151\rsid4947640\rsid6963519\rsid7282308\rsid9646566\rsid10227609\rsid10382262\rsid10704264\rsid10752920\rsid11218240\rsid12087820\rsid12282547\rsid12348097\rsid13134628\rsid13253201\rsid14370152\rsid14894181\rsid15038176}{\mmathPr
-\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo4\dy1\hr13\min41}{\revtim\yr2019\mo4\dy18\hr5\min26}{\version23}{\edmins102}
-{\nofpages7}{\nofwords1913}{\nofchars10905}{\nofcharsws12793}{\vern99}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid4482658\rsid4940151\rsid4947640\rsid6963519\rsid7282308\rsid9646566\rsid10227609\rsid10382262\rsid10704264\rsid10752920\rsid11218240\rsid12087820\rsid12282547\rsid12348097\rsid12615477\rsid13134628\rsid13253201\rsid14370152\rsid14894181\rsid15038176}
+{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo4\dy1\hr13\min41}{\revtim\yr2019\mo5\dy3\hr8\min9}{\version24}{\edmins102}
+{\nofpages7}{\nofwords1912}{\nofchars10903}{\nofcharsws12790}{\vern99}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot14894181 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot14894181 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
 {\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NjWyNLIwMTE1MzA1NTJU0lEKTi0uzszPAykwqgUA3LCJWSwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
@@ -216,21 +216,21 @@ http://carlwebster.com/using-my-citrix-pvs-powershell-documentation-script-with-
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bcc00000068007400740070003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f007500730069006e0067002d006d0079002d006300690074007200690078002d0070007600
 73002d0070006f007700650072007300680065006c006c002d0064006f00630075006d0065006e0074006100740069006f006e002d007300630072006900700074002d0077006900740068002d00720065006d006f00740069006e0067002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00000075000073
-00000000000000000058632ef0}}}{\fldrslt {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid14894181\charrsid7282308 \hich\af37\dbch\af31505\loch\f37 http://carlwebster.com/using-my-citrix-pvs-powershell-documentation-script-with-remoting/}}}
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 
+00000000000000000058632ef000}}}{\fldrslt {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid14894181\charrsid7282308 \hich\af37\dbch\af31505\loch\f37 http://carlwebster.com/using-my-citrix-pvs-powershell-documentation-script-with-remoting/}
+}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid14894181 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547\charrsid12282547 \hich\af37\dbch\af31505\loch\f37 
 http://carlwebster.com/pvs-v2-documentation-script-has-been-updated-17-jun-2013/}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 \hich\af37\dbch\af31505\loch\f37 " }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid4090611 
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bba00000068007400740070003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f007000760073002d00760032002d0064006f00630075006d0065006e007400610074006900
-6f006e002d007300630072006900700074002d006800610073002d006200650065006e002d0075007000640061007400650064002d00310037002d006a0075006e002d0032003000310033002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000000334500000000008000ff4558727463}}}{\fldrslt {
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid12282547\charrsid11218240 \hich\af37\dbch\af31505\loch\f37 http://carlwebs\hich\af37\dbch\af31505\loch\f37 ter.com/pvs-v2-documentation-script-has-been-updated-17-jun-2013/}}}
+6f006e002d007300630072006900700074002d006800610073002d006200650065006e002d0075007000640061007400650064002d00310037002d006a0075006e002d0032003000310033002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000000334500000000008000ff455872746300}}}{\fldrslt 
+{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid12282547\charrsid11218240 \hich\af37\dbch\af31505\loch\f37 http://carlwebs\hich\af37\dbch\af31505\loch\f37 ter.com/pvs-v2-documentation-script-has-been-updated-17-jun-2013/}}}
 \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 
 \par }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547\charrsid12282547 \hich\af37\dbch\af31505\loch\f37 
 http://carlwebster.com/error-in-the-provisioning-services-7-0-powershell-programmer-guide-for-windows-8-and-server-2012/}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 \hich\af37\dbch\af31505\loch\f37 " }{\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid4090611 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b0a01000068007400740070003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f006500720072006f0072002d0069006e002d007400680065002d00700072006f0076006900
 730069006f006e0069006e0067002d00730065007200760069006300650073002d0037002d0030002d0070006f007700650072007300680065006c006c002d00700072006f006700720061006d006d00650072002d00670075006900640065002d0066006f0072002d00770069006e0064006f00770073002d0038002d0061
-006e0064002d007300650072007600650072002d0032003000310032002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00000000000000000000806300005f30c063}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid12282547\charrsid11218240 
+006e0064002d007300650072007600650072002d0032003000310032002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00000000000000000000806300005f30c06300}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf19\insrsid12282547\charrsid11218240 
 \hich\af37\dbch\af31505\loch\f37 http://carlwebster.com/error-in-the-provisioning-services-7-0-powershell-programmer-guide-for-windows-8-and-s\hich\af37\dbch\af31505\loch\f37 erver-2012/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid12282547 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2585069 \hich\af37\dbch\af31505\loch\f37 Full help text is available.
@@ -450,11 +450,11 @@ http://carlwebster.com/error-in-the-provisioning-services-7-0-powershell-program
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par \hich\af2\dbch\af31505\loch\f2         NAME: PVS_Assessment.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4940151 \hich\af2\dbch\af31505\loch\f2 8}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640\charrsid4947640 
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12615477 \hich\af2\dbch\af31505\loch\f2 9}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640\charrsid4947640 
 \par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 AUTHOR: Carl Webster, Sr. Solutions Architect at Choice Solutions (with a lot of }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640 
 \par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640\charrsid4947640 \hich\af2\dbch\af31505\loch\f2 help from BG a, now former,Citrix dev)
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: April }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12348097 \hich\af2\dbch\af31505\loch\f2 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid201962 \hich\af2\dbch\af31505\loch\f2 8}{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640\charrsid4947640 \hich\af2\dbch\af31505\loch\f2 , 2019
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12615477 \hich\af2\dbch\af31505\loch\f2 May 3}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640\charrsid4947640 \hich\af2\dbch\af31505\loch\f2 
+, 2019
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
@@ -498,7 +498,7 @@ http://carlwebster.com/error-in-the-provisioning-services-7-0-powershell-program
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640\charrsid4947640 \hich\af2\dbch\af31505\loch\f2 XDAdmin@domain.tld -To }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640 
 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "mailto:}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640\charrsid4947640 \hich\af2\dbch\af31505\loch\f2 ITGroup@domain.tld}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640 
 \hich\af2\dbch\af31505\loch\f2 " }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10382262 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4c0000006d00610069006c0074006f003a0049005400470072006f0075007000400064006f006d00610069006e002e0074006c0064000000795881f43b1d7f48af2c825dc485276300000000a5ab000300460000}}
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4c0000006d00610069006c0074006f003a0049005400470072006f0075007000400064006f006d00610069006e002e0074006c0064000000795881f43b1d7f48af2c825dc485276300000000a5ab00030046000000}}
 }{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid4947640\charrsid599009 \hich\af2\dbch\af31505\loch\f2 ITGroup@domain.tld}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640\charrsid4947640 \hich\af2\dbch\af31505\loch\f2 -ComputerName DHCPServer01
 \par 
@@ -521,14 +521,14 @@ http://carlwebster.com/error-in-the-provisioning-services-7-0-powershell-program
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "mailto:}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640\charrsid4947640 
 \hich\af2\dbch\af31505\loch\f2 webster@carlwebster.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640 \hich\af2\dbch\af31505\loch\f2 " }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10382262 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b560000006d00610069006c0074006f003a00770065006200730074006500720040006300610072006c0077006500620073007400650072002e0063006f006d000000795881f43b1d7f48af2c825dc485276300000000
-a5ab000321690000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid4947640\charrsid599009 \hich\af2\dbch\af31505\loch\f2 webster@carlwebster.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid4947640\charrsid4947640 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640\charrsid4947640 \hich\af2\dbch\af31505\loch\f2 sending to }
-{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "mailto:}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640\charrsid4947640 \hich\af2\dbch\af31505\loch\f2 
+a5ab00032169000000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid4947640\charrsid599009 \hich\af2\dbch\af31505\loch\f2 webster@carlwebster.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid4947640\charrsid4947640 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640\charrsid4947640 \hich\af2\dbch\af31505\loch\f2 
+sending to }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "mailto:}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640\charrsid4947640 \hich\af2\dbch\af31505\loch\f2 
 ITGroup@carlwebster.com}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640 \hich\af2\dbch\af31505\loch\f2 " }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10382262 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b560000006d00610069006c0074006f003a0049005400470072006f007500700040006300610072006c0077006500620073007400650072002e0063006f006d000000795881f43b1d7f48af2c825dc485276300000000
-a5ab000321420031}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid4947640\charrsid599009 \hich\af2\dbch\af31505\loch\f2 ITGroup@carlwebster.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid4947640\charrsid4947640 .}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640\charrsid4947640 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640 
+a5ab00032142003100}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf19\insrsid4947640\charrsid599009 \hich\af2\dbch\af31505\loch\f2 ITGroup@carlwebster.com}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid4947640\charrsid4947640 .}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640\charrsid4947640 
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not v\hich\af2\dbch\af31505\loch\f2 alid to send email, the user will be prompted }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640\charrsid4947640 \hich\af2\dbch\af31505\loch\f2 to enter valid}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640 \hich\af2\dbch\af31505\loch\f2  }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4947640\charrsid4947640 \hich\af2\dbch\af31505\loch\f2 credentials.
 \par 
@@ -536,8 +536,8 @@ a5ab000321420031}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\u
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\PVS_Assessment.ps1 -CSV
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use \hich\af2\dbch\af31505\loch\f2 all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     LocalHost for AdminAddr\hich\af2\dbch\af31505\loch\f2 ess.
 \par \hich\af2\dbch\af31505\loch\f2     Creates a CSV file for each Appendix.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
@@ -660,8 +660,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000005080
-b12bd1f5d401feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000c010
+2c83b101d501feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/PVS_Assessment_Script_ChangeLog.txt
+++ b/PVS_Assessment_Script_ChangeLog.txt
@@ -4,6 +4,12 @@
 #@carlwebster on Twitter
 #http://www.CarlWebster.com
 
+#Version 1.19 3-May-2019
+#	Remove the following regkeys from analysis as they are for target devices, not PVS Servers 
+#		(thanks to Johan Parlevliet for pointing this out)
+#		HKLM:\SYSTEM\CurrentControlSet\Services\BNIStack\Parameters\SocketOpenRetryIntervalMS      
+#		HKLM:\SYSTEM\CurrentControlSet\Services\BNIStack\ParametersSocketOpenRetryLimit           
+
 #Version 1.18 18-Apr-2019
 #	Fix bug reported by Johan Parlevliet 
 #		If either SQL server name has a port number, remove it before finding the IP address


### PR DESCRIPTION
#Version 1.19 3-May-2019
#	Remove the following regkeys from analysis as they are for target devices, not PVS Servers 
#		(thanks to Johan Parlevliet for pointing this out)
#		HKLM:\SYSTEM\CurrentControlSet\Services\BNIStack\Parameters\SocketOpenRetryIntervalMS      
#		HKLM:\SYSTEM\CurrentControlSet\Services\BNIStack\ParametersSocketOpenRetryLimit